### PR TITLE
Changed response tot checkupdate when container is up to date

### DIFF
--- a/locale/en.json
+++ b/locale/en.json
@@ -109,7 +109,7 @@
     "stopped_container": "🔴 Container *$1* has been *stopped*",
     "created_container": "🔵 Container *$1* has been *created*",
     "available_update": "⬆️ *Update available*:\n*$1*",
-    "already_updated": "✅ *$1* container was already up to date",
+    "already_updated": "✅ *$1* container is up to date",
     "start_a_container": "🟢 Click on a container to start it",
     "stop_a_container": "🔴 Click on a container to stop it",
     "restart_a_container": "🟢 Click on a container to restart it",

--- a/locale/es.json
+++ b/locale/es.json
@@ -109,7 +109,7 @@
     "stopped_container": "🔴 El contenedor *$1* se ha *detenido*",
     "created_container": "🔵 El contenedor *$1* se ha *creado*",
     "available_update": "⬆️ *Actualización disponible*:\n*$1*",
-    "already_updated": "✅ El contenedor *$1* ya se encuentra actualizado",
+    "already_updated": "✅ El contenedor *$1* está actualizado",
     "start_a_container": "🟢 Pulsa en un contenedor para iniciarlo",
     "stop_a_container": "🔴 Pulsa en un contenedor para detenerlo",
     "restart_a_container": "🟢 Pulsa en un contenedor para reiniciarlo",

--- a/locale/nl.json
+++ b/locale/nl.json
@@ -109,7 +109,7 @@
    "stopped_container": "🔴 Container *$1* is *gestopt*",
    "created_container": "🔵 Container *$1* is *aangemaakt*",
    "available_update": "⬆️ *Update beschikbaar*:\n*$1*",
-   "already_updated": "✅ *$1* container was al up to date",
+   "already_updated": "✅ *$1* container is up to date",
    "start_a_container": "🟢 Klik op een container om deze te starten",
    "stop_a_container": "🔴 Klik op een container om deze te stoppen",
    "restart_a_container": "🟢 Klik op een container om deze opnieuw te starten",


### PR DESCRIPTION
The previous response tot the /checkupdate command sounded like a warning or error message when the container was up to date 'already'.

(Sorry, still trying to get the hang of github.)