### PR TITLE
Refactor Docker setup and update .gitignore to improve local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 .env
 .DS_Store
+
+# Local development files
+__pycache__
+cache
+schedule

--- a/Dockerfile_local
+++ b/Dockerfile_local
@@ -13,15 +13,12 @@ ENV LANGUAGE ES
 ENV EXTENDED_MESSAGES 0
 ENV TZ UTC
 
-RUN apk add --no-cache python3 py3-pip tzdata
-RUN pip3 install pyparsing==3.2.0
-RUN pip3 install requests==2.32.3
-RUN pip3 install pyTelegramBotAPI==4.23.0
-RUN pip3 install docker==7.1.0
-RUN pip install PyYAML==6.0.2
-RUN pip install croniter==5.0.1
-
 WORKDIR /app
-COPY . .
 
-ENTRYPOINT ["python3", "docker-controller-bot.py"]
+RUN apk add --no-cache python3 py3-pip tzdata npm
+COPY requirements.txt /app/requirements.txt
+RUN pip3 install -r requirements.txt
+RUN npm install -g nodemon
+
+# Legacy watch needed for nodemon to work with docker volumes
+ENTRYPOINT ["nodemon","--legacy-watch", "docker-controller-bot.py"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,7 +6,7 @@ services:
         - .env
         volumes:
             - /var/run/docker.sock:/var/run/docker.sock # NO CAMBIAR
-            - /ruta/para/guardar/las/programaciones:/app/schedule # CAMBIAR LA PARTE IZQUIERDA
+            - ./:/app # CAMBIAR LA PARTE IZQUIERDA
         build:
           context: .
           dockerfile: ./Dockerfile_local

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+pyparsing==3.2.0
+requests==2.32.3
+pyTelegramBotAPI==4.23.0
+docker==7.1.0
+PyYAML==6.0.2
+croniter==5.0.1


### PR DESCRIPTION
While researching to fix some bug in **issues**, I was wondering how to improve the local development of the container. So as not to have to delete the image and recreate it at each change to the file. For this I have proposed:
- To use locally the volume of the entire docker folder in /app. Add to the .gitignore file the new files to ignore.
- Create a requirements.txt file to avoid having to modify the Docker file every time you want to add a dependency.
- Install nodemon so that every time we modify the docker-controller-bot.py file locally, we do **hot reload** of it. And run it in the entrypoint of the Dockerfile file.

Issue attached #57